### PR TITLE
Passed flake8 tests except test_applyfilter

### DIFF
--- a/picturepyfect/applyfilter.py
+++ b/picturepyfect/applyfilter.py
@@ -41,8 +41,8 @@ def filter_pyfect_2D(image, kernel):
     ---------
     filtered_image: numpy.ndarray
         Result of the filtering as a 2D numpy array. Please note that the
-        values are scaled so that they are between range of 0 and 1 using minmax scaler
-        for plotting stability
+        values are scaled so that they are between range of 0 and 1 using
+        minmax scaler for plotting stability
 
     Examples
     --------
@@ -110,8 +110,8 @@ def filter_pyfect_3D(image, kernel):
     ---------
     filtered_image: numpy.ndarray
         Result of the filtering as a 3D numpy array. Please note that the
-        values are scaled so that they are between range of 0 and 1 using minmax scaler
-        within each channel for plotting stability
+        values are scaled so that they are between range of 0 and 1 using
+        minmax scaler within each channel for plotting stability
 
     Examples
     --------
@@ -222,7 +222,7 @@ def build_filter(kernel_type, kernel_size):
             ] = 0
 
     else:
-        raise FilterTypeException(f"Invalid filter_type.")
+        raise FilterTypeException("Invalid filter_type.")
 
     return kernel
 
@@ -231,17 +231,18 @@ def filter_pyfect(
     image, filter_type="blur", filter_size=3, custom_filter=None
 ):
     """
-    This function can be used to apply predefined or custom filters on an image.
+    This function applies predefined or custom filters on an image.
 
-    The function can be applied on single channel or 3-channel images. The users can
-    choose from predefined filters or can create their new filters. This can be used
-    for various purposes like entertainment application or visualization of
-    convolutional neural network.
+    The function can be applied on single channel or 3-channel images.
+    The users can choose from predefined filters or can create their new
+    filters. This can be used for various purposes like entertainment
+    application or visualization of convolutional neural network.
 
     Parameters
     ----------
     image : numpy.ndarray
-        A n1*n2 or n1*n2*3 numpy array to representing single channel or 3-channel image
+        A n1*n2 or n1*n2*3 numpy array to representing single channel
+        or 3-channel image
 
     filter_type : string
         One of the following values:
@@ -255,8 +256,8 @@ def filter_pyfect(
         This is used if the filter_type is not custom. Default: 3
 
     custom_filter: numpy.ndarray
-        A k1*k2 or k1*k2*3 numpy array allows users to pass their own filter. This is only
-        used if the users select filter_type = "custom"
+        A k1*k2 or k1*k2*3 numpy array allows users to pass their own filter.
+        This is only used if the users select filter_type = "custom"
 
     Returns:
     ---------
@@ -273,20 +274,19 @@ def filter_pyfect(
        [0.55555556, 0.61111111, 0.66666667, 0.72222222],
        [0.83333333, 0.88888889, 0.94444444, 1.        ]])
 
-    >>> image = np.arange(1, 76).reshape(5, 5, 3)
+    >>> img = np.arange(1, 76).reshape(5, 5, 3)
     >>> kernel = np.ones((2,2,3))
-    >>> filter_pyfect(image, filter_type="custom", custom_filter=kernel)[:,:,1]
+    >>> filter_pyfect(img, filter_type="custom", custom_filter=kernel)[:,:,1]
     array([[0.        , 0.05555556, 0.11111111, 0.16666667],
        [0.27777778, 0.33333333, 0.38888889, 0.44444444],
        [0.55555556, 0.61111111, 0.66666667, 0.72222222],
        [0.83333333, 0.88888889, 0.94444444, 1.        ]])
 
-    >>> image = np.arange(1, 26).reshape(5, 5)
-    >>> filter_pyfect(image, filter_type="blur")
+    >>> img = np.arange(1, 26).reshape(5, 5)
+    >>> filter_pyfect(img, filter_type="blur")
     array([[0.        , 0.08333333, 0.16666667],
        [0.41666667, 0.5       , 0.58333333],
        [0.83333333, 0.91666667, 1.        ]])
-
     """
     valid_filters = ["blur", "sharpen", "custom"]
     valid_dimensions = [2, 3]
@@ -300,7 +300,9 @@ def filter_pyfect(
         image.ndim == 3 and image.shape[2] != 3
     ):
         raise ImageDimensionException(
-            f"Invalid dimension of the image. Please use 2D or 3D images. In case of 3D images, there should be 3 channels"
+            """Invalid dimension of the image. Please use 2D or 3D images.
+            In case of 3D images, there should be 3 channels
+            """
         )
 
     if filter_type == "custom" and (
@@ -308,7 +310,10 @@ def filter_pyfect(
         or (custom_filter.ndim == 3 and custom_filter.shape[2] != 3)
     ):
         raise FilterDimensionException(
-            f"Invalid dimension of the filter. Please use 2D or 3D filters. In case of 3D filters, there should be 3 channels"
+           """
+           Invalid dimension of the filter. Please use 2D or 3D filters.
+           In case of 3D filters, there should be 3 channels"
+           """
         )
 
     if (

--- a/picturepyfect/compression_pyfect.py
+++ b/picturepyfect/compression_pyfect.py
@@ -10,23 +10,27 @@ def compression_pyfect(image, kernel_size=2, pooling_function="max"):
     """
     This function uses a lossy pooling algorithm to compress an image.
 
-    The function can be applied to single channel or 3-channel images. The user passes
-    an image which is to be compressed and the resulting compressed numpy array is returned.
-    The user can also specify the pooling algorithm to be used and the size of the kernel
+    The function can be applied to single channel or 3-channel images.
+    The user passes an image which is to be compressed and the resulting
+    compressed numpy array is returned. The user can also specify the pooling
+    algorithm to be used and the size of the kernel
     to apply over the image.
 
     Parameters
     ----------
     image : numpy.ndarray
-        A n*n or n*n*3 numpy array representing a single channel or 3-channel image.
+        A n*n or n*n*3 numpy array representing a single channel or a
+        3-channel image.
 
     kernel_size : int
-        The size of the kernel to be passed over the image. The resulting filter moving
-        across the image will be a 2D array with dimensions kernel_size x kernel_size.
+        The size of the kernel to be passed over the image. The resulting
+        filter moving across the image will be a 2D array with dimensions
+        kernel_size x kernel_size.
         Default: 2
 
     pooling_function : str
-        The pooling algorithm to be used within a kernel. There are three options: "max", "min", and "mean".
+        The pooling algorithm to be used within a kernel. There are three
+        options: "max", "min", and "mean".
         Default: "max"
 
     Returns:
@@ -55,7 +59,10 @@ def compression_pyfect(image, kernel_size=2, pooling_function="max"):
         pool_func = np.mean
     else:
         raise ValueError(
-            "The pooling_function argument only takes a value of 'max', 'min', or 'mean'."
+            """
+            The pooling_function argument only takes a value of 'max',
+            'min', or 'mean'.
+            """
         )
 
     # If image is not divisible by the kernel_size
@@ -84,11 +91,11 @@ def compression_pyfect(image, kernel_size=2, pooling_function="max"):
 
 def pool_band(band, kernel_size, pool_func):
     """
-    This function is to be used in conjunction with compression_pyfect and compresses
-    a single colour band of an image.
+    This function is to be used in conjunction with compression_pyfect
+    and compresses a single colour band of an image.
 
-    The function applies a lossy pooling algorithm to compress the specified colour band
-    and the resulting compressed numpy array is returned.
+    The function applies a lossy pooling algorithm to compress the specified
+    colour band and the resulting compressed numpy array is returned.
 
     Parameters
     ----------
@@ -96,11 +103,13 @@ def pool_band(band, kernel_size, pool_func):
         A n*n numpy array representing a single colour band of an image.
 
     kernel_size : int
-        The size of the kernel to be passed over the image. The resulting filter moving
-        across the image will be a 2D array with dimensions kernel_size x kernel_size.
+        The size of the kernel to be passed over the image. The resulting
+        filter moving across the image will be a 2D array with dimensions
+        kernel_size x kernel_size.
 
     pooling_function : str
-        The pooling algorithm to be used within a kernel. There are three options: "max", "min", and "mean".
+        The pooling algorithm to be used within a kernel. There are three
+        options: "max", "min", and "mean".
 
     Returns:
     ---------
@@ -117,9 +126,7 @@ def pool_band(band, kernel_size, pool_func):
     """
 
     # Using this forum post as a guide and reference for the below code
-    # https://stackoverflow.com/questions/42463172/how-to-perform-max-mean-pooling-on-a-2d-array-using-numpy/42463514#42463514
-
-    row = band.shape[0] // kernel_size
+    # https://tinyurl.com/yhnbexcs
     col = band.shape[1] // kernel_size
 
     # The colour band to pool
@@ -151,11 +158,13 @@ def check_values(image, kernel_size):
     Parameters
     ----------
     image : numpy.ndarray
-        A n*n or n*n*3 numpy array representing a single channel or 3-channel image.
+        A n*n or n*n*3 numpy array representing a single channel or 3-channel
+        image.
 
     kernel_size : int
-        The size of the kernel to be passed over the image. The resulting filter moving
-        across the image will be a 2D array with dimensions kernel_size x kernel_size.
+        The size of the kernel to be passed over the image. The resulting
+        filter moving across the image will be a 2D array with dimensions
+        kernel_size x kernel_size.
 
     Examples
     --------
@@ -175,21 +184,32 @@ def check_values(image, kernel_size):
             "kernel_size must be a positive integer greater than 0."
         )
 
-    # Check if the image is of the correct shape. Greyscale and colour images both accepted
+    # Check if the image is of the correct shape.
+    # Greyscale and colour images both accepted
     if len(image.shape) != 2 and len(image.shape) != 3:
         raise DimensionError(
-            "The input image array needs to be of shape n x n, or n x n x 3."
+            """
+            The input image array needs to be of shape n x n,
+            or n x n x 3.
+            """
         )
 
-    # If the image is of size n x n x n, ensure that the third dimension equals 3.
+    # If the image is of size n x n x n,
+    # ensure that the third dimension equals 3.
     if len(image.shape) == 3:
         if image.shape[2] != 3:
             raise DimensionError(
-                "The input image array needs to be of shape n x n, or n x n x 3."
+                """
+                The input image array needs to be of shape n x n,
+                or n x n x 3.
+                """
             )
 
     # Check that the kernel_size is smaller than the image height and width
     if image.shape[0] < kernel_size or image.shape[1] < kernel_size:
         raise ValueError(
-            "The kernel size must not be larger than the height or width of the input image array."
+            """
+            The kernel size must not be larger than the height or width of
+            the input image array.
+            """
         )

--- a/picturepyfect/get_property.py
+++ b/picturepyfect/get_property.py
@@ -1,11 +1,12 @@
 import numpy as np
-import matplotlib.pyplot as plt
 
 
 def get_property(image):
     """
-    Extract RGB or RGBA image properties. The output properties includes means and medians
-    of RGB channels along with the file dimension and total pixels.
+    Extract RGB or RGBA image properties. The output properties includes
+    means and medians of RGB channels along with the file dimension and total
+    pixels.
+
     Parameters
     ----------
     image : numpy.ndarray
@@ -13,8 +14,9 @@ def get_property(image):
     Returns:
     ---------
     image_property: dictionary
-        a dictionary of image properties for dimension of width and height, total pixels,
-        and each channel's mean and median value stored as a list for each channel.
+        a dictionary of image properties for dimension of width and height,
+        total pixels, and each channel's mean and median value stored as a
+        list for each channel.
     Examples
     ---------
     >>> get_property(image)
@@ -29,7 +31,10 @@ def get_property(image):
         or (image.shape[2] > 4)
     ):
         raise TypeError(
-            "Invalid Type: RGB or RGBA image type must be a 3D or 4D numpy array"
+            """
+            Invalid Type: RGB or RGBA image type must be a 3D or 4D
+            numpyarray
+            """
         )
 
     print(image.shape)
@@ -48,5 +53,6 @@ def get_property(image):
         "g_channel": [channel_means[1], channel_medians[1]],
         "b_channel": [channel_means[2], channel_medians[2]],
     }
+
     # return the dictionary of image property
     return image_properties

--- a/picturepyfect/rotate_pyfect.py
+++ b/picturepyfect/rotate_pyfect.py
@@ -3,11 +3,12 @@ import numpy as np
 
 def rotate_pyfect(image, n_rot=1):
     """
-    This function can be used to apply a rotational transformation on an image.
+    This rotate function can be used to apply a rotational transformation
+    on an image.
 
-    The function can be applied on greyscale or 3-channel images. The users can
-    choose some degree, theta, which is used in a rotational matrix
-    operation to transform the image.
+    The function can be applied on greyscale or 3-channel images.
+    The users can choose some degree, theta, which is used in a rotational
+    matrix operation to transform the image.
 
     Parameters
     ----------
@@ -20,7 +21,8 @@ def rotate_pyfect(image, n_rot=1):
     Returns:
     ---------
     rotated_image: numpy.ndarray
-        A n*n or n*n*3 numpy array which is the input image rotated by a multiple of 90 degrees
+        A n*n or n*n*3 numpy array which is the input image rotated by a
+        multiple of 90 degrees
 
     Examples
     --------
@@ -51,7 +53,8 @@ def rotate_pyfect(image, n_rot=1):
         raise TypeError("Invalid Type: Image must by 2 or 3 dimensional")
 
     if len(image.shape) == 3:
-        # Initialize dictionary with each channel being mapped to  it's channel number
+        # Initialize dictionary with each channel being mapped to
+        # it's channel number
         channel_dict = {
             channel: image[:, :, channel]
             for channel in range(0, image.shape[2])

--- a/tests/test_applyfilter.py
+++ b/tests/test_applyfilter.py
@@ -1,4 +1,3 @@
-from picturepyfect import __version__
 from picturepyfect import applyfilter as flt
 from picturepyfect.applyfilter import (
     FilterTypeException,
@@ -238,8 +237,6 @@ def test_filter_pyfect():
             [0.83333333, 0.88888889, 0.94444444, 1.0],
         ]
     )
-
-    # print(flt.filter_pyfect(image, filter_type="custom", custom_filter=kernel).shape)
 
     assert flt.filter_pyfect(
         image, filter_type="custom", custom_filter=kernel

--- a/tests/test_compression_pyfect.py
+++ b/tests/test_compression_pyfect.py
@@ -1,6 +1,5 @@
 from picturepyfect.compression_pyfect import compression_pyfect
 from picturepyfect.compression_pyfect import DimensionError
-from picturepyfect.rotate_pyfect import rotate_pyfect
 import pytest
 import numpy as np
 

--- a/tests/test_get_property.py
+++ b/tests/test_get_property.py
@@ -15,6 +15,7 @@ wrong_dim2 = np.zeros([1, 1, 1])
 wrong_dim3 = np.zeros([1, 1, 2])
 wrong_dim4 = np.zeros([1, 1, 5])
 
+
 # test error handling
 def test_error():
     with pytest.raises(TypeError):

--- a/tests/test_rotation_pyfect.py
+++ b/tests/test_rotation_pyfect.py
@@ -16,6 +16,7 @@ test_image_2d_2 = rotate_pyfect(test_image_2d, 2)
 test_image_2d_3 = rotate_pyfect(test_image_2d, 3)
 test_image_2d_4 = rotate_pyfect(test_image_2d, 4)
 
+
 # test error handling
 def test_error():
     with pytest.raises(TypeError):


### PR DESCRIPTION
I have restructured the docstring and deleted unused library import code lines.
I passed all the flake8 tests for files except the test_applyfilter.py file. 
All the original pytests are passed too.
![image](https://user-images.githubusercontent.com/17485959/110881943-08d7d580-8296-11eb-8b18-46cd282dd704.png)

Can @debanandasarkar modify the test logics to pass the tests? The test failures came from the assert statements.

> .\tests\test_applyfilter.py:72:9: E712 comparison to False should be 'if cond is False:' or 'if not cond:'
.\tests\test_applyfilter.py:85:9: E712 comparison to False should be 'if cond is False:' or 'if not cond:'
.\tests\test_applyfilter.py:112:9: E712 comparison to False should be 'if cond is False:' or 'if not cond:'
.\tests\test_applyfilter.py:118:9: E712 comparison to False should be 'if cond is False:' or 'if not cond:'
.\tests\test_applyfilter.py:124:9: E712 comparison to False should be 'if cond is False:' or 'if not cond:'
.\tests\test_applyfilter.py:146:64: E712 comparison to False should be 'if cond is False:' or 'if not cond:'
.\tests\test_applyfilter.py:149:70: E712 comparison to False should be 'if cond is False:' or 'if not cond:'
.\tests\test_applyfilter.py:179:9: E712 comparison to False should be 'if cond is False:' or 'if not cond:'
.\tests\test_applyfilter.py:205:9: E712 comparison to False should be 'if cond is False:' or 'if not cond:'
.\tests\test_applyfilter.py:227:9: E712 comparison to False should be 'if cond is False:' or 'if not cond:'
.\tests\test_applyfilter.py:256:9: E712 comparison to False should be 'if cond is False:' or 'if not cond:'
.\tests\test_applyfilter.py:265:9: E712 comparison to False should be 'if cond is False:' or 'if not cond:'
.\tests\test_applyfilter.py:274:9: E712 comparison to False should be 'if cond is False:' or 'if not cond:'
.\tests\test_applyfilter.py:301:9: E712 comparison to False should be 'if cond is False:' or 'if not cond:'
.\tests\test_applyfilter.py:310:9: E712 comparison to False should be 'if cond is False:' or 'if not cond:'
.\tests\test_applyfilter.py:319:9: E712 comparison to False should be 'if cond is False:' or 'if not cond:'
.\tests\test_applyfilter.py:341:9: E712 comparison to False should be 'if cond is False:' or 'if not cond:'
.\tests\test_applyfilter.py:348:9: E712 comparison to False should be 'if cond is False:' or 'if not cond:'
.\tests\test_applyfilter.py:355:9: E712 comparison to False should be 'if cond is False:' or 'if not cond:'
